### PR TITLE
Tested and working release

### DIFF
--- a/MMM-Ferroamp.js
+++ b/MMM-Ferroamp.js
@@ -7,7 +7,7 @@
 Module.register("MMM-Ferroamp",{
     // Default module config.
     defaults: {
-        url: "https://professional.ferroamp.com/",
+        url: "https://portal.ferroamp.com/",
         apiKey: "", //Enter API key in config.js not here
         siteId: "12345", //Sample site
         refInterval: 1000 * 60 * 5, //5 minutes
@@ -19,14 +19,14 @@ Module.register("MMM-Ferroamp",{
         Log.info("Starting module: " + this.name);
 
 		if (config.language == 'sv') {
-			this.titles = ["Aktuell effekt:", "Energi idag:", "Energi denna månad:", "Energi detta år:", "Energi från start:"];
+			this.titles = ["Aktuell effekt:", "Energi idag:", "Energi från start:"];
 		}
 		else {
-			this.titles = ["Current Power:", "Daily Energy:", "Last Month:", "Last Year:", "Lifetime Energy:"];
+			this.titles = ["Current Power:", "Daily Energy:", "Lifetime Energy:"];
 		}
 
-		this.suffixes = ["Watt", "kWh", "kWh", "kWh", "MWh"];
-		this.results = ["Loading", "Loading", "Loading", "Loading", "Loading"];
+		this.suffixes = ["Watt", "kWh", "MWh"];
+		this.results = ["Loading", "Loading", "Loading"];
         this.loaded = false;
         this.getSolarData();
 
@@ -61,16 +61,14 @@ Module.register("MMM-Ferroamp",{
     //Handle node helper response
     socketNotificationReceived: function(notification, payload) {
     if (notification === "FERROAMP_DATA") {
-	    var currentPower = payload.overview.currentPower.power;
+	    var currentPower = payload.data.pvp.val;
 	    if (currentPower > 1000) {
                this.results[0] = (currentPower / 1000).toFixed(2) + " kW";
             } else {
                this.results[0] = currentPower + " Watt";
             }
-            this.results[1] = (payload.overview.lastDayData.energy / 1000).toFixed(2) + " kWh";
-            this.results[2] = (payload.overview.lastMonthData.energy / 1000).toFixed(2) + " kWh";
-            this.results[3] = (payload.overview.lastYearData.energy / 1000).toFixed(2) + " kWh";
-            this.results[4] = (payload.overview.lifeTimeData.energy / 1000000).toFixed(2) + " MWh";
+            this.results[1] = (payload.overview.data.pvetoday.val / 1000).toFixed(2) + " kWh";
+            this.results[2] = (payload.overview.data.pve.val / 1000000).toFixed(2) + " MWh";
             this.loaded = true;
             this.updateDom(1000);
         }

--- a/MMM-Ferroamp.js
+++ b/MMM-Ferroamp.js
@@ -67,8 +67,8 @@ Module.register("MMM-Ferroamp",{
             } else {
                this.results[0] = currentPower + " Watt";
             }
-            this.results[1] = (payload.overview.data.pvetoday.val / 1000).toFixed(2) + " kWh";
-            this.results[2] = (payload.overview.data.pve.val / 1000000).toFixed(2) + " MWh";
+            this.results[1] = (payload.data.pvetoday.val / 1000).toFixed(2) + " kWh";
+            this.results[2] = (payload.data.pve.val / 1000000).toFixed(2) + " MWh";
             this.loaded = true;
             this.updateDom(1000);
         }

--- a/node_helper.js
+++ b/node_helper.js
@@ -14,7 +14,7 @@ module.exports = NodeHelper.create({
 		console.log("Notification: " + notification + " Payload: " + payload);
 
 		if (notification === "GET_FERROAMP") {
-			var ferroAmpUrl = payload.config.url + payload.config.siteId + "/overview?api_key=" + payload.config.apiKey;
+			var ferroAmpUrl = payload.config.url + "api?type=pvdisplay&api_key=" + payload.config.apiKey + "&fid=" + payload.config.siteId;
 			request(ferroAmpUrl, function (error, response, body) {
 				if (!error && response.statusCode == 200) {
 					var jsonData = JSON.parse(body);


### PR DESCRIPTION
Changed API baseurl from professional.ferroamp.com to portal.ferroamp.com as professional.ferroamp.com is deprecated and doesn't work with API-calls.

Fixed the API-calls and Json parsing to work with the Ferroamp cloud API to fetch data for current power, daily energy and lifetime energy.